### PR TITLE
Add English input switching on tmux prefix key press

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -20,6 +20,10 @@
 unbind-key c-b
 set -g prefix c-a
 
+# Switch to English input method when prefix key is pressed (macOS, requires im-select)
+# brew install im-select
+bind-key -n C-a run-shell "im-select com.apple.keylayout.ABC 2>/dev/null || true" \; switch-client -T prefix
+
 # Index starts from 1
 set -g base-index 1
 


### PR DESCRIPTION
## Summary

- `Ctrl+A` (prefix) 입력 시 자동으로 영문 입력기로 전환하는 기능 추가
- macOS `im-select` 유틸리티를 사용하여 한영 전환 처리
- prefix 동작은 `switch-client -T prefix`로 기존과 동일하게 유지

## 변경 내용

```tmux
# Switch to English input method when prefix key is pressed (macOS, requires im-select)
# brew install im-select
bind-key -n C-a run-shell "im-select com.apple.keylayout.ABC 2>/dev/null || true" \; switch-client -T prefix
```

## 사전 조건

```sh
brew install im-select
```

## Test plan

- [ ] tmux 실행 중 한글 입력 상태에서 `Ctrl+A` 입력
- [ ] 입력기가 영문으로 자동 전환되는지 확인
- [ ] prefix 이후 키 바인딩 (split, new-window 등) 정상 동작 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)